### PR TITLE
Add IPFS mirroring script

### DIFF
--- a/docs/decentralized-mirrors.md
+++ b/docs/decentralized-mirrors.md
@@ -1,0 +1,31 @@
+# Decentralized Mirror Network
+
+This guide describes how to mirror each Omniversal-Landing domain into a peer-to-peer network for archival or distribution purposes. The process downloads each site as static files and republishes it using [IPFS](https://ipfs.tech/).
+
+## Prerequisites
+
+- Linux or macOS environment with `wget` and `ipfs` installed
+- A text file listing all domains to mirror (default: `omni-domains.txt`)
+
+## Steps
+
+1. Populate a file called `omni-domains.txt` in the repository root. List one domain per line, for example:
+
+```
+ghost.omniversal.cloud
+portal.omniversal.cloud
+```
+
+2. Run the helper script to mirror all domains and publish them to IPFS:
+
+```bash
+bash scripts/mirror-ipfs.sh
+```
+
+Each domain will be mirrored under `mirrors/<domain>` and a corresponding `<domain>.cid` file will contain the IPFS CID.
+
+3. Optionally, pin the resulting CIDs on other IPFS nodes or gateways. This distributes the content across the decentralized network. You may also configure a Tor hidden service or other alternative transport layer pointing to the static files if deeper anonymity is desired.
+
+---
+
+The mirrored sites are static copies. Dynamic features requiring server-side logic will not be preserved.

--- a/scripts/mirror-ipfs.sh
+++ b/scripts/mirror-ipfs.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+set -euo pipefail
+
+DOMAIN_FILE=${1:-omni-domains.txt}
+
+if [ ! -f "$DOMAIN_FILE" ]; then
+  echo "Domain file $DOMAIN_FILE not found" >&2
+  exit 1
+fi
+
+mkdir -p mirrors
+
+while IFS= read -r domain || [ -n "$domain" ]; do
+  [ -z "$domain" ] && continue
+  target="mirrors/$domain"
+  echo "Mirroring $domain..."
+  wget --mirror --page-requisites --convert-links --adjust-extension --no-parent "https://$domain" -P "$target"
+  if command -v ipfs >/dev/null 2>&1; then
+    ipfs add -r -Q "$target" > "$target.cid"
+    echo "Added $domain to IPFS: $(cat "$target.cid")"
+  else
+    echo "ipfs command not found; skipped publishing $domain" >&2
+  fi
+done < "$DOMAIN_FILE"
+
+echo "All done."


### PR DESCRIPTION
## Summary
- document how to mirror Omniversal domains via IPFS
- add helper script `mirror-ipfs.sh`

## Testing
- `yarn test:all` *(fails: package missing in lockfile)*
- `yarn lint` *(fails: package missing in lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_68439d2467b88331a9a534eaef2413b6

## Summary by Sourcery

Add a helper script and documentation to mirror Omniversal domains to IPFS for decentralized archival and distribution.

New Features:
- Introduce `mirror-ipfs.sh` script to download site snapshots and publish them to IPFS.

Documentation:
- Add `docs/decentralized-mirrors.md` guide detailing prerequisites and usage steps for IPFS mirroring.